### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/nicks-ms-subscription/5592fa6b-26ec-441c-a782-1d96d13c5752/d60ed1d7-5706-4ac7-aebb-4d33926d3a40/_apis/work/boardbadge/520abf95-caf1-438c-8466-a53e708a8e2b)](https://dev.azure.com/nicks-ms-subscription/5592fa6b-26ec-441c-a782-1d96d13c5752/_boards/board/t/d60ed1d7-5706-4ac7-aebb-4d33926d3a40/Microsoft.RequirementCategory)
 # maug3010
 Azure DevOps Projects - see the [wiki](https://github.com/nikkh/maug3010/wiki) for detailed instructions


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#750](https://dev.azure.com/nicks-ms-subscription/5592fa6b-26ec-441c-a782-1d96d13c5752/_workitems/edit/750). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.